### PR TITLE
Enable custom content and multi-selector highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Default: string
 - isOpen (boolean; optional): Whether the Tour component is currently open
 - steps (dict; optional): The steps in the tour component. steps has the following type: list of dicts containing keys 'selector', 'content', 'position', 'action', 'style', 'stepInteraction', 'navDotAriaLabel'.
 Those keys have the following types:
-  - selector (string; optional)
-  - content (string; required)
+  - selector (string | list of strings; optional)
+  - content (string | dash component; required)
   - position (list of numbers | a value equal to: 'top', 'right', 'bottom', 'left', 'center'; optional)
   - action (optional)
   - style (dict; optional)

--- a/src/jl__dashtour.jl
+++ b/src/jl__dashtour.jl
@@ -20,8 +20,8 @@ Default: string
 - `isOpen` (Bool; optional): Whether the Tour component is currently open
 - `steps` (optional): The steps in the tour component. steps has the following type: Array of lists containing elements 'selector', 'content', 'position', 'action', 'style', 'stepInteraction', 'navDotAriaLabel'.
 Those elements have the following types:
-  - `selector` (String; optional)
-  - `content` (String; required)
+  - `selector` (String | Array{String}; optional)
+  - `content` (Any; required)
   - `position` (Array of Reals | a value equal to: 'top', 'right', 'bottom', 'left', 'center'; optional)
   - `action` (optional)
   - `style` (Dict; optional)

--- a/src/jl__tour.jl
+++ b/src/jl__tour.jl
@@ -15,7 +15,7 @@ Default: string
 - `isOpen` (Bool; optional): Whether the Tour component is currently open
 - `steps` (optional): The steps in the tour component. steps has the following type: Array of lists containing elements 'selector', 'content', 'position', 'action', 'style', 'stepInteraction', 'navDotAriaLabel'.
 Those elements have the following types:
-  - `selector` (String; optional)
+  - `selector` (String | Array{String}; optional)
   - `content` (a list of or a singular dash component, string or number | dash component; required)
   - `position` (Array of Reals | a value equal to: 'top', 'right', 'bottom', 'left', 'center'; optional)
   - `action` (optional)

--- a/src/lib/components/DashTour.react.js
+++ b/src/lib/components/DashTour.react.js
@@ -8,6 +8,54 @@ export default class DashTour extends Component {
         super(props);
     }
 
+    componentDidUpdate(prevProps) {
+        const {steps, isOpen, CurrentStep} = this.props;
+
+        if (!steps) return;
+
+        const prevStepIndex = (prevProps.CurrentStep || 0) - 1;
+        const newStepIndex = (CurrentStep || 0) - 1;
+
+        if (prevProps.isOpen && !isOpen) {
+            // tour was closed, remove any highlights
+            if (steps[prevStepIndex]) {
+                this.removeExtraHighlights(steps[prevStepIndex].selector);
+            }
+        }
+
+        if (isOpen) {
+            // if step changed remove previous and add new
+            if (prevProps.CurrentStep !== CurrentStep || !prevProps.isOpen) {
+                if (steps[prevStepIndex]) {
+                    this.removeExtraHighlights(steps[prevStepIndex].selector);
+                }
+                if (steps[newStepIndex]) {
+                    this.addExtraHighlights(steps[newStepIndex].selector);
+                }
+            }
+        }
+    }
+
+    addExtraHighlights = (selectors) => {
+        if (!selectors) return;
+        const list = Array.isArray(selectors) ? selectors : selectors.split(',');
+        list.forEach(sel => {
+            document.querySelectorAll(sel.trim()).forEach(el => {
+                el.classList.add('dash-tour-highlight');
+            });
+        });
+    };
+
+    removeExtraHighlights = (selectors) => {
+        if (!selectors) return;
+        const list = Array.isArray(selectors) ? selectors : selectors.split(',');
+        list.forEach(sel => {
+            document.querySelectorAll(sel.trim()).forEach(el => {
+                el.classList.remove('dash-tour-highlight');
+            });
+        });
+    };
+
     closeTour = () => {
         // eslint-disable-next-line no-invalid-this
         this.props.setProps({ isOpen: false});
@@ -57,11 +105,13 @@ DashTour.propTypes = {
      * The steps in the tour component
      */
     steps: PropTypes.arrayOf(PropTypes.shape({
-        'selector': PropTypes.string,
-        'content': PropTypes.oneOfType([
+        'selector': PropTypes.oneOfType([
             PropTypes.string,
-            // PropTypes.element,
-            // PropTypes.func,
+            PropTypes.arrayOf(PropTypes.string)
+        ]),
+        'content': PropTypes.oneOfType([
+            PropTypes.node,
+            PropTypes.func,
         ]).isRequired,
         'position':PropTypes.oneOfType([
             PropTypes.arrayOf(PropTypes.number),

--- a/src/lib/components/css/DashTour.css
+++ b/src/lib/components/css/DashTour.css
@@ -27,3 +27,9 @@ body {
   line-height: 1.3;
   color: #2d2323;
 }
+
+.dash-tour-highlight {
+  box-shadow: 0 0 0 4px rgba(92, 183, 183, 0.8);
+  transition: box-shadow 0.3s ease;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- allow steps to receive dash components as content
- support multiple selectors per step and highlight them
- document new step properties in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_687828c76fa88320a0e9a53053547cfa