### PR TITLE
Add basic React test for DashTour component

### DIFF
--- a/src/lib/components/__tests__/DashTour.test.js
+++ b/src/lib/components/__tests__/DashTour.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import {render, fireEvent, screen} from '@testing-library/react';
+import DashTour from '../DashTour.react';
+
+describe('DashTour component', () => {
+    const steps = [
+        { selector: '#el1', content: 'Step 1' },
+        { selector: '#el2', content: 'Step 2' }
+    ];
+
+    test('opens and highlights the first step', () => {
+        document.body.innerHTML = `
+            <div id="el1">First</div>
+            <div id="el2">Second</div>`;
+
+        render(<DashTour isOpen steps={steps} />);
+        const target = document.querySelector('#el1');
+        expect(target.classList.contains('dash-tour-highlight')).toBe(true);
+    });
+
+    test('removes highlight when closed', () => {
+        document.body.innerHTML = `
+            <div id="el1">First</div>`;
+
+        const {rerender} = render(<DashTour isOpen steps={steps} />);
+        rerender(<DashTour isOpen={false} steps={steps} />);
+
+        const target = document.querySelector('#el1');
+        expect(target.classList.contains('dash-tour-highlight')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- add DashTour.test.js to illustrate how to test the tour component

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: dash module not found)*

------
https://chatgpt.com/codex/tasks/task_e_687832d803c883209b37e647855e88dc