### PR TITLE
Fix DashTour initialization error

### DIFF
--- a/dash_tour_component/__init__.py
+++ b/dash_tour_component/__init__.py
@@ -23,6 +23,10 @@ class DashTour(Component):
 
     @_explicitize_args
     def __init__(self, children=None, **kwargs):
+        # Dash adds `_explicit_args` to kwargs when the component is
+        # initialised.  The base ``Component`` does not expect this
+        # argument, so remove it before calling ``super``.
+        kwargs.pop("_explicit_args", None)
         super(DashTour, self).__init__(children=children, **kwargs)
 
 # Define JavaScript and CSS assets


### PR DESCRIPTION
## Summary
- remove `_explicit_args` from kwargs before calling Dash `Component.__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68784949c6b483208898911cfd062b27